### PR TITLE
Increase code coverage thresholds

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,8 +29,8 @@ sonar.exclusions=**/node_modules/**,**/*.spec.ts,**/*.test.ts,**/test/**
 
 # Code Coverage Quality Gates
 sonar.coverage.exclusions=**/*Test.java,**/*IT.java,**/*TestCase.java
-sonar.coverage.minimum.target=50.0
-sonar.coverage.minimum.required=30.0
+sonar.coverage.minimum.target=80.0
+sonar.coverage.minimum.required=50.0
 
 # Duplication Quality Gates  
 sonar.cpd.exclusions=**/*Test.java,**/*IT.java,**/*TestCase.java
@@ -53,8 +53,8 @@ sonar.issue.ignore.multicriteria.e2.ruleKey=**
 # Define Quality Gate Conditions
 sonar.qualitygate.condition.1.metric=new_coverage
 sonar.qualitygate.condition.1.op=LT
-sonar.qualitygate.condition.1.warning=50
-sonar.qualitygate.condition.1.error=30
+sonar.qualitygate.condition.1.warning=80
+sonar.qualitygate.condition.1.error=50
 sonar.qualitygate.condition.2.metric=new_duplicated_lines_density
 sonar.qualitygate.condition.2.op=GT
 sonar.qualitygate.condition.2.warning=3


### PR DESCRIPTION
This PR increases the code coverage thresholds in the SonarQube configuration:

- Minimum required coverage: 30% -> 50%
- Target coverage: 50% -> 80%

These changes apply to both the sonar.coverage properties and the quality gate conditions.